### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "php": ">=5.4",
     "symfony/symfony": "~2.3|~3.0",
     "league/flysystem": "~1.0",
-    "league/glide": "0.3.*"
+    "league/glide": "~1.0"
   },
   "require-dev": {
     "phpunit/phpunit": "4.2.6",


### PR DESCRIPTION
Can you update your bundle to support the latest 1.0 release of glide? I had some issues getting it installed with the symfony glide adapter as that is only 1.0 ready. 

Not sure this change is the best way, maybe it works with a | like for symfony 2.3 and 3.0? 
