### PR TITLE
Symfony 4.0 fix

### DIFF
--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -95,7 +95,7 @@
 
         <!-- Server Factory -->
 
-        <service id="ashleydawson.glide.server_factory" class="%ashleydawson.glide.server_factory.class%">
+        <service id="ashleydawson.glide.server_factory" class="%ashleydawson.glide.server_factory.class%" public="true">
             <argument type="service" id="ashleydawson.glide.api" />
         </service>
 


### PR DESCRIPTION
This makes the server_factory public, so it can be used as instructed in the example in README.md