### PR TITLE
Support Symfony 5 & 6, Glide 2, and Flysystem 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: php
 
 php:
+  - 8.1
+  - 8.0
+  - 7.4
+  - 7.3
   - 7.2
-  - 7.1
-  - 7.0
-  - 5.6
-  - 5.5
 
 # This triggers builds to run on the new TravisCI infrastructure.
 # See: http://docs.travis-ci.com/user/workers/container-based-infrastructure/
@@ -17,11 +17,10 @@ cache:
     - $HOME/.composer/cache
 
 before_install:
-  - if [[ $TRAVIS_PHP_VERSION =~ ^hhvm ]]; then echo 'hhvm.jit = false' >> /etc/hhvm/php.ini ; fi
   - composer self-update --stable -n
 
 install:
   - travis_retry composer install --no-suggest --prefer-dist -n -o
 
 script:
-  - vendor/phpunit/phpunit/phpunit --coverage-text
+  - bin/phpunit --coverage-text

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,8 @@
   "require": {
     "php": ">=7.2",
     "symfony/framework-bundle": "^4.4|^5.0|^6.0",
-    "league/flysystem": "^1.0",
-    "league/glide-symfony": "^1.0"
+    "league/flysystem": "^2.0",
+    "league/glide-symfony": "^2.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.5",

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
     }
   ],
   "require": {
-    "php": ">=5.4",
-    "symfony/framework-bundle": "^3.0|^4.0",
+    "php": ">=7.2",
+    "symfony/framework-bundle": "^4.4|^5.0|^6.0",
     "league/flysystem": "^1.0",
     "league/glide-symfony": "^1.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -29,11 +29,14 @@
     "league/glide-symfony": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^4.8",
-    "matthiasnoback/symfony-dependency-injection-test": "^1.0"
+    "phpunit/phpunit": "^8.5",
+    "matthiasnoback/symfony-dependency-injection-test": "^4.3"
   },
   "autoload": {
     "psr-4": { "AshleyDawson\\GlideBundle\\": "src" }
+  },
+  "autoload-dev": {
+    "psr-4": { "AshleyDawson\\GlideBundle\\Tests\\": "tests" }
   },
   "config": {
     "bin-dir": "bin"

--- a/src/AshleyDawsonGlideBundle.php
+++ b/src/AshleyDawsonGlideBundle.php
@@ -16,10 +16,8 @@ class AshleyDawsonGlideBundle extends Bundle
     /**
      * {@inheritdoc}
      */
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
-        parent::build($container);
-
         $container->addCompilerPass(new ManipulatorCollectionCompilerPass());
     }
 }

--- a/src/DependencyInjection/AshleyDawsonGlideExtension.php
+++ b/src/DependencyInjection/AshleyDawsonGlideExtension.php
@@ -2,11 +2,11 @@
 
 namespace AshleyDawson\GlideBundle\DependencyInjection;
 
+use Symfony\Component\Config\Definition\Processor;
+use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
-use Symfony\Component\Config\FileLocator;
-use Symfony\Component\Config\Definition\Processor;
 
 /**
  * Class AshleyDawsonGlideExtension
@@ -18,7 +18,7 @@ class AshleyDawsonGlideExtension extends Extension
     /**
      * {@inheritdoc}
      */
-    public function load(array $config, ContainerBuilder $container)
+    public function load(array $config, ContainerBuilder $container): void
     {
         $configuration = new Configuration();
         $processor = new Processor();

--- a/src/DependencyInjection/AshleyDawsonGlideExtension.php
+++ b/src/DependencyInjection/AshleyDawsonGlideExtension.php
@@ -25,13 +25,13 @@ class AshleyDawsonGlideExtension extends Extension
 
         $config = $processor->processConfiguration($configuration, $config);
 
-        $container->setParameter('ashleydawson.glide.max_image_size',
-            $config['max_image_size']);
-
-        $container->setParameter('ashleydawson.glide.image_manager_driver',
-            $config['image_manager_driver']);
-
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.xml');
+
+        $container->getDefinition('ashleydawson.glide.manipulator.size')
+            ->setArgument('$maxImageSize', $config['max_image_size']);
+
+        $container->getDefinition('ashleydawson.glide.image_manager')
+            ->setArgument('$config', ['driver' => $config['image_manager_driver']]);
     }
 }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -2,8 +2,8 @@
 
 namespace AshleyDawson\GlideBundle\DependencyInjection;
 
-use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 /**
  * Class Configuration
@@ -15,7 +15,7 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritdoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('ashley_dawson_glide');
         $rootNode = \method_exists($treeBuilder, 'getRootNode')

--- a/src/DependencyInjection/Container/ManipulatorCollectionCompilerPass.php
+++ b/src/DependencyInjection/Container/ManipulatorCollectionCompilerPass.php
@@ -2,8 +2,8 @@
 
 namespace AshleyDawson\GlideBundle\DependencyInjection\Container;
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
@@ -16,7 +16,7 @@ class ManipulatorCollectionCompilerPass implements CompilerPassInterface
     /**
      * {@inheritdoc}
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if ( ! $container->has('ashleydawson.glide.manipulator_collection')) {
             return;

--- a/src/Manipulator/ManipulatorCollection.php
+++ b/src/Manipulator/ManipulatorCollection.php
@@ -20,7 +20,7 @@ class ManipulatorCollection implements ManipulatorCollectionInterface
     /**
      * {@inheritdoc}
      */
-    public function addManipulator(ManipulatorInterface $manipulator)
+    public function addManipulator(ManipulatorInterface $manipulator): void
     {
         $class = get_class($manipulator);
 
@@ -35,7 +35,7 @@ class ManipulatorCollection implements ManipulatorCollectionInterface
     /**
      * {@inheritdoc}
      */
-    public function getManipulators()
+    public function getManipulators(): array
     {
         return $this->_manipulators;
     }

--- a/src/Manipulator/ManipulatorCollectionInterface.php
+++ b/src/Manipulator/ManipulatorCollectionInterface.php
@@ -18,12 +18,12 @@ interface ManipulatorCollectionInterface
      * @return void
      * @throws \AshleyDawson\GlideBundle\Exception\ManipulatorAlreadyExistsInCollectionException
      */
-    public function addManipulator(ManipulatorInterface $manipulator);
+    public function addManipulator(ManipulatorInterface $manipulator): void;
 
     /**
      * Get the collection of manipulators as an array
      *
      * @return ManipulatorInterface[]
      */
-    public function getManipulators();
+    public function getManipulators(): array;
 }

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -4,20 +4,11 @@
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <parameters>
-
-        <parameter key="ashleydawson.glide.manipulator_collection.class">AshleyDawson\GlideBundle\Manipulator\ManipulatorCollection</parameter>
-        <parameter key="ashleydawson.glide.image_manager.class">Intervention\Image\ImageManager</parameter>
-        <parameter key="ashleydawson.glide.api.class">AshleyDawson\GlideBundle\Api\Api</parameter>
-        <parameter key="ashleydawson.glide.server_factory.class">AshleyDawson\GlideBundle\Server\ServerFactory</parameter>
-
-    </parameters>
-
     <services>
 
         <!-- Manipulator Collection -->
 
-        <service id="ashleydawson.glide.manipulator_collection" class="%ashleydawson.glide.manipulator_collection.class%" />
+        <service id="ashleydawson.glide.manipulator_collection" class="AshleyDawson\GlideBundle\Manipulator\ManipulatorCollection" />
 
         <!-- Manipulators -->
 
@@ -30,7 +21,6 @@
         </service>
 
         <service id="ashleydawson.glide.manipulator.size" class="League\Glide\Manipulators\Size">
-            <argument>%ashleydawson.glide.max_image_size%</argument>
             <tag name="ashleydawson.glide.manipulators" />
         </service>
 
@@ -63,6 +53,7 @@
         </service>
 
         <service id="ashleydawson.glide.manipulator.watermark" class="League\Glide\Manipulators\Watermark">
+            <argument key="$watermarks" type="service" id="ashleydawson.glide.filesystem.watermark" on-invalid="null"/>
             <tag name="ashleydawson.glide.manipulators" />
         </service>
 
@@ -80,23 +71,21 @@
 
         <!-- Image Manager -->
 
-        <service id="ashleydawson.glide.image_manager" class="%ashleydawson.glide.image_manager.class%">
-            <argument type="collection">
-                <argument key="driver" type="string">%ashleydawson.glide.image_manager_driver%</argument>
-            </argument>
+        <service id="ashleydawson.glide.image_manager" class="Intervention\Image\ImageManager">
+            <argument type="collection"/>
         </service>
 
         <!-- API -->
 
-        <service id="ashleydawson.glide.api" class="%ashleydawson.glide.api.class%">
+        <service id="AshleyDawson\GlideBundle\Api\Api">
             <argument type="service" id="ashleydawson.glide.image_manager" />
             <argument type="service" id="ashleydawson.glide.manipulator_collection" />
         </service>
 
         <!-- Server Factory -->
 
-        <service id="ashleydawson.glide.server_factory" class="%ashleydawson.glide.server_factory.class%" public="true">
-            <argument type="service" id="ashleydawson.glide.api" />
+        <service id="AshleyDawson\GlideBundle\Server\ServerFactory" public="true">
+            <argument type="service" id="AshleyDawson\GlideBundle\Api\Api" />
         </service>
 
     </services>

--- a/src/Server/ServerFactory.php
+++ b/src/Server/ServerFactory.php
@@ -31,7 +31,7 @@ class ServerFactory implements ServerFactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function create(FilesystemOperator $source, FilesystemOperator $cache)
+    public function create(FilesystemOperator $source, FilesystemOperator $cache): Server
     {
         $server = new Server($source, $cache, $this->_api);
         $server->setResponseFactory(new SymfonyResponseFactory());

--- a/src/Server/ServerFactory.php
+++ b/src/Server/ServerFactory.php
@@ -2,7 +2,7 @@
 
 namespace AshleyDawson\GlideBundle\Server;
 
-use League\Flysystem\FilesystemInterface;
+use League\Flysystem\FilesystemOperator;
 use League\Glide\Api\ApiInterface;
 use League\Glide\Responses\SymfonyResponseFactory;
 
@@ -31,7 +31,7 @@ class ServerFactory implements ServerFactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function create(FilesystemInterface $source, FilesystemInterface $cache)
+    public function create(FilesystemOperator $source, FilesystemOperator $cache)
     {
         $server = new Server($source, $cache, $this->_api);
         $server->setResponseFactory(new SymfonyResponseFactory());

--- a/src/Server/ServerFactoryInterface.php
+++ b/src/Server/ServerFactoryInterface.php
@@ -2,7 +2,7 @@
 
 namespace AshleyDawson\GlideBundle\Server;
 
-use League\Flysystem\FilesystemInterface;
+use League\Flysystem\FilesystemOperator;
 
 /**
  * Interface ServerFactoryInterface
@@ -14,9 +14,9 @@ interface ServerFactoryInterface
     /**
      * Create a Glide server with source and cache filesystems
      *
-     * @param FilesystemInterface $source
-     * @param FilesystemInterface $cache
+     * @param FilesystemOperator $source
+     * @param FilesystemOperator $cache
      * @return \AshleyDawson\GlideBundle\Server\Server;
      */
-    public function create(FilesystemInterface $source, FilesystemInterface $cache);
+    public function create(FilesystemOperator $source, FilesystemOperator $cache);
 }

--- a/src/Server/ServerFactoryInterface.php
+++ b/src/Server/ServerFactoryInterface.php
@@ -18,5 +18,5 @@ interface ServerFactoryInterface
      * @param FilesystemOperator $cache
      * @return \AshleyDawson\GlideBundle\Server\Server;
      */
-    public function create(FilesystemOperator $source, FilesystemOperator $cache);
+    public function create(FilesystemOperator $source, FilesystemOperator $cache): Server;
 }

--- a/tests/AshleyDawsonGlideBundleTest.php
+++ b/tests/AshleyDawsonGlideBundleTest.php
@@ -26,7 +26,7 @@ class AshleyDawsonGlideBundleTest extends AbstractExtensionTestCase
      *
      * @return ExtensionInterface[]
      */
-    protected function getContainerExtensions()
+    protected function getContainerExtensions(): array
     {
         return [
             new AshleyDawsonGlideExtension(),

--- a/tests/AshleyDawsonGlideBundleTest.php
+++ b/tests/AshleyDawsonGlideBundleTest.php
@@ -17,7 +17,7 @@ class AshleyDawsonGlideBundleTest extends AbstractExtensionTestCase
     {
         $this->load();
 
-        $this->assertContainerBuilderHasService('ashleydawson.glide.server_factory');
+        $this->assertContainerBuilderHasService('AshleyDawson\GlideBundle\Server\ServerFactory');
     }
 
     /**

--- a/tests/Manipulator/ManipulatorCollectionTest.php
+++ b/tests/Manipulator/ManipulatorCollectionTest.php
@@ -4,30 +4,31 @@ namespace AshleyDawson\GlideBundle\Tests\Manipulator;
 
 use AshleyDawson\GlideBundle\Manipulator\ManipulatorCollection;
 use League\Glide\Manipulators\ManipulatorInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class ManipulatorCollectionTest
  *
  * @package AshleyDawson\GlideBundle\Tests\Manipulator
  */
-class ManipulatorCollectionTest extends \PHPUnit_Framework_TestCase
+class ManipulatorCollectionTest extends TestCase
 {
     /**
      * @var ManipulatorCollection
      */
     private $_manipulatorCollection;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->_manipulatorCollection = new ManipulatorCollection();
     }
 
-    public function testInitialCollectionState()
+    public function testInitialCollectionState(): void
     {
         $this->assertCount(0, $this->_manipulatorCollection->getManipulators());
     }
 
-    public function testAddManipulator()
+    public function testAddManipulator(): void
     {
         $this->_manipulatorCollection->addManipulator(
             $this->buildMockManipulatorInterface()
@@ -36,7 +37,7 @@ class ManipulatorCollectionTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(1, $this->_manipulatorCollection->getManipulators());
     }
 
-    public function testGetMultipleManipulators()
+    public function testGetMultipleManipulators(): void
     {
         $this->assertCount(0, $this->_manipulatorCollection->getManipulators());
 
@@ -57,9 +58,9 @@ class ManipulatorCollectionTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    public function testAddManipulatorAlreadyExists()
+    public function testAddManipulatorAlreadyExists(): void
     {
-        $this->setExpectedException('AshleyDawson\GlideBundle\Exception\ManipulatorAlreadyExistsInCollectionException');
+        $this->expectException('AshleyDawson\GlideBundle\Exception\ManipulatorAlreadyExistsInCollectionException');
 
         $this->_manipulatorCollection->addManipulator(
             $this->buildMockManipulatorInterface('Mock_Manip')
@@ -70,14 +71,15 @@ class ManipulatorCollectionTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    private function buildMockManipulatorInterface($mockClassName = null) {
+    private function buildMockManipulatorInterface($mockClassName = null): ManipulatorInterface
+    {
         return $this
             ->getMockBuilder('League\Glide\Manipulators\ManipulatorInterface')
             ->setMockClassName($mockClassName ? $mockClassName : $this->_buildRandomMockManipulatorClassName())
             ->getMock();
     }
 
-    private function _buildRandomMockManipulatorClassName()
+    private function _buildRandomMockManipulatorClassName(): string
     {
         return sprintf('Mock_Manip_%s', md5(uniqid(null, true)));
     }

--- a/tests/Server/ServerFactoryTest.php
+++ b/tests/Server/ServerFactoryTest.php
@@ -7,20 +7,21 @@ use Intervention\Image\ImageManager;
 use League\Flysystem\Adapter\Local;
 use League\Flysystem\Filesystem;
 use League\Glide\Api\Api;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class ServerFactoryTest
  *
  * @package AshleyDawson\GlideBundle\Tests\Server
  */
-class ServerFactoryTest extends \PHPUnit_Framework_TestCase
+class ServerFactoryTest extends TestCase
 {
     /**
      * @var ServerFactory
      */
     private $_serverFactory;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $api = new Api(
             new ImageManager([
@@ -46,7 +47,7 @@ class ServerFactoryTest extends \PHPUnit_Framework_TestCase
         $this->_serverFactory = new ServerFactory($api);
     }
 
-    public function testCreateServer()
+    public function testCreateServer(): void
     {
         $source = $this->_getLocalFilesystem('/source');
         $cache = $this->_getLocalFilesystem('/cache');
@@ -56,7 +57,7 @@ class ServerFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('League\Glide\Server', $server);
     }
 
-    private function _getLocalFilesystem($prefix = '')
+    private function _getLocalFilesystem($prefix = ''): Filesystem
     {
         return new Filesystem(new Local(TESTS_TMP_DIR . $prefix));
     }

--- a/tests/Server/ServerFactoryTest.php
+++ b/tests/Server/ServerFactoryTest.php
@@ -4,8 +4,8 @@ namespace AshleyDawson\GlideBundle\Tests\Server;
 
 use AshleyDawson\GlideBundle\Server\ServerFactory;
 use Intervention\Image\ImageManager;
-use League\Flysystem\Adapter\Local;
 use League\Flysystem\Filesystem;
+use League\Flysystem\Local\LocalFilesystemAdapter;
 use League\Glide\Api\Api;
 use PHPUnit\Framework\TestCase;
 
@@ -59,6 +59,6 @@ class ServerFactoryTest extends TestCase
 
     private function _getLocalFilesystem($prefix = ''): Filesystem
     {
-        return new Filesystem(new Local(TESTS_TMP_DIR . $prefix));
+        return new Filesystem(new LocalFilesystemAdapter(TESTS_TMP_DIR . $prefix));
     }
 }


### PR DESCRIPTION
The main objective was to support Symfony 5 & 6, Glide / Glide Symfony 2, and Flysystem 2. 

**NOTE:** These changes definitely require major version bump.

Also changed:
- Symfony 3 is now unsupported so dropped
- Minimum PHP requirement of >= 7.2 was the lowest supported by both Glide & Flysystem
- PHPUnit 8.5 as it is the last major version to test PHP 7.2+, and Travis config changed accordingly
- Updated README

Happy to make changes upon request, and happy to hand over as well.